### PR TITLE
Refactor upload script

### DIFF
--- a/paste.sh
+++ b/paste.sh
@@ -1,49 +1,65 @@
 #!/bin/sh
-URL="http://paste.awesom.eu"
-DEFAULTUSER=""
-# Print the paste url ?
-PRINT="YES"
-# Copy the paste url ?
-COPY=""
-COPY_CMD=""
 
-which xclip > /dev/null
-if [ $? -eq 0 ] ; then
-    COPY_CMD="`which xclip` -i"
-else
-    which xsel > /dev/null
-    if [ $? -eq 0 ] ; then
-        COPY_CMD="`which xsel`"
-    fi
-fi
+usage="Usage: $0 [-s] [-l language] [-u user] [-c] [ -C copy_command ] [ -p pastebin_url ] file\n
+-s: toggles silent mode (do not print the final URL)\n
+-c: copies the final URL to clipboard"
 
-if [ -e "$1" -o "$1" = "-" ] ; then
-    FILE="$1"
-else
-    echo "Usage: $0 [file|-] [lang] [user]"
+if [[ "$#" -lt 1 ]] ; then
+    echo -e $usage;
     exit
 fi
 
-if [ -n "$2" ] ; then
-    LANG="$2"
+pastebin_url="http://paste.awesom.eu"
+user=""
+copy=""
+lang=""
+print="yes"
+
+which xclip > /dev/null
+if [ $? -eq 0 ] ; then
+    copy_cmd="`which xclip` -i"
 else
-    EXT="`echo \"$1\"|sed -e 's/.*\.//'`"
-    LANG=""
+    which xsel > /dev/null
+    if [ $? -eq 0 ] ; then
+        copy_cmd="`which xsel`"
+    fi
 fi
 
-if [ -n "$3" ] ; then
-    USER="$3"
-else
-    USER="$DEFAULTUSER"
+while getopts  :l:u:csC:p: option
+do
+    case $option in
+        l) language="$OPTARG";;
+
+        u) user="$OPTARG";;
+
+        c) copy="yes";;
+
+        s) print="";;
+
+        C) copy_command="$OPTARG";;
+
+        p) pastebin_url="$OPTARG";;
+
+
+        ?) echo -e $usage;
+           exit;;
+    esac
+done
+
+shift $(($OPTIND - 1))
+file=$1
+
+if [ ! $language ] ; then
+    ext="`echo \"$file\"|sed -e 's/.*\.//'`"
 fi
 
-PASTE=$(curl -d "hl=${LANG}&ext=${EXT}&user=${USER}&escape=on&script" --data-urlencode paste@${FILE} "$URL" 2>/dev/null)
+paste=$(curl -d "hl=${language}&ext=${ext}&user=${user}&escape=on&script" --data-urlencode paste@${file} "$pastebin_url" 2>/dev/null)
 
-FINAL="$URL/$PASTE"
-if [ "$PRINT" = "YES" ] ; then
-    echo "$FINAL"
+final="$pastebin_url/$paste"
+if [ "$print" = "yes" ] ; then
+    echo "$final"
 fi
 
-if [ "$COPY" = "YES" -a -n "$COPY_CMD" ] ; then
-    echo "$FINAL" | $COPY_CMD
+if [ "$copy" = "yes" -a -n "$copy_command" ] ; then
+    echo "$final" | $copy_command
 fi


### PR DESCRIPTION
Hello,

I have refactored the upload script. Previously, we could only change the language and the user, and these were supplied as postional arguments (which is awkward when we want to change the user but not the language). I did that using `getopts`, which is a Bourne shell builtin and therefore portable. I added some flags and updated the help message. It isn't, of course, backwards-compatible but I still think it makes the upload script much more flexible.  
Because a short help message is worth a thousand words, here's the usage message of the new script:

```
Usage: ./paste.sh [-s] [-l language] [-u user] [-c] [ -C copy_command ] [ -p pastebin_url ] file
 -s: toggles silent mode (do not print the final URL)
 -c: copies the final URL to clipboard
```

Thanks in advance for your consideration,  
Matthias Rabault
